### PR TITLE
MCP.begin() required in example

### DIFF
--- a/Examples/MCP3424_OneShotConversion/MCP3424_OneShotConversion.ino
+++ b/Examples/MCP3424_OneShotConversion/MCP3424_OneShotConversion.ino
@@ -17,6 +17,7 @@ long Voltage;
 void setup(){ 
 
   Serial.begin(9600); // start serial for output
+  MCP.begin(0);
   MCP.configuration(1,16,0,1); // Channel 1, 16 bits resolution, one-shot mode, amplifier gain = 1
 
 }


### PR DESCRIPTION
Just a minor change to make the One Shot example work. 

Tested on an ESP8266