### PR TITLE
fixed bit-shift error in MCP342x::setConfiguration

### DIFF
--- a/MCP342x.cpp
+++ b/MCP342x.cpp
@@ -68,7 +68,8 @@ uint8_t cfgbyte=0;
  
 _resolution=resolution;
 _PGA=pga;
-_LSB = 2048000000/(1<<(resolutionConvert[_resolution]-1));
+uint32_t divisor = 1;
+_LSB = 2048000000/(divisor<<(resolutionConvert[_resolution]-1));
 
 cfgbyte |= (channel & 0x3) << 5;
 cfgbyte |= (mode & 0x1) << 4;


### PR DESCRIPTION
This pull request fixes a bug which causes the program to hang in 18-bit resolution mode. 

In 18-bit resolution mode, line 71 of MCP342x.cpp left-shifts a 1 by 17 places, which is intended to produce a value of 131072. However in my case, the compiler decided that the 1 was a 16-bit value so the 1 was left-shifted right off the end of the variable leaving nothing but zeros. This resulted in a divide by zero error which hung the program on my Arduino UNO. I fixed the bug by explicitly specifying that the 1 is a 32-bit value and now the program works well.